### PR TITLE
fix behavior path planner route refine

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -9,7 +9,7 @@
     backward_length_buffer_for_end_of_pull_out: 5.0
     minimum_pull_over_length: 16.0
 
-    refine_goal_search_radius_range: 7.5
+    refine_goal_search_radius_range: 1.0
 
     # parameters for turn signal decider
     turn_signal_intersection_search_distance: 30.0
@@ -20,8 +20,8 @@
     turn_signal_on_swerving: true
 
     enable_akima_spline_first: false
-    input_path_interval: 2.0
-    output_path_interval: 2.0
+    input_path_interval: 1.0
+    output_path_interval: 1.0
 
     visualize_maximum_drivable_area: true
 

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -9,7 +9,7 @@
     backward_length_buffer_for_end_of_pull_out: 5.0
     minimum_pull_over_length: 16.0
 
-    refine_goal_search_radius_range: 1.0
+    refine_goal_search_radius_range: 2.5
 
     # parameters for turn signal decider
     turn_signal_intersection_search_distance: 30.0


### PR DESCRIPTION
hokazeルートの走行に必要なパラメタ修正

パスの補完距離の変更: 2.0m → 1.0m
ゴール地点の探索半径: 7.5m → 2.5m

ゴール地点の探索半径は、ゴール付近でgoal poseへのyaw角の補正をどれくらいの距離から行うかという値（だったはず）でもあるので、goal近辺でのyawを安定させるために狭くした

